### PR TITLE
Potential fix for code scanning alert no. 21: Flask app is run in debug mode

### DIFF
--- a/examples/log_viewer.py
+++ b/examples/log_viewer.py
@@ -447,6 +447,11 @@ def main():
         default=5000,
         help="Port to bind to (default: 5000)",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable Flask debug mode (not for production use)",
+    )
 
     args = parser.parse_args()
 
@@ -460,7 +465,7 @@ def main():
     print(f"API Jobs: http://{args.host}:{args.port}/api/jobs")
     print("\nPress Ctrl+C to stop")
 
-    app.run(host=args.host, port=args.port, debug=True)
+    app.run(host=args.host, port=args.port, debug=args.debug)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Potential fix for [https://github.com/Jurel89/homelab-subtitle-service/security/code-scanning/21](https://github.com/Jurel89/homelab-subtitle-service/security/code-scanning/21)

To fix this, the app should not always run with `debug=True`. Instead, provide a CLI option to enable debug mode explicitly, defaulting to `False`, and pass that value to `app.run`. This preserves existing behavior for users who need debug mode (they can pass `--debug`), while making the safer choice the default.

Concretely in `examples/log_viewer.py`:

- Add a new `--debug` flag to the `argparse` parser in `main()`, e.g. `parser.add_argument("--debug", action="store_true", help="Enable Flask debug mode (not for production)")`.
- Change the `app.run` call on line 463 from `debug=True` to `debug=args.debug`.

No new imports or functions are required; everything uses the existing `argparse` setup.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
